### PR TITLE
Upgrade NaN to 1.5 to support io.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Native Access to Mac OS-X FSEvents",
   "main": "fsevents.js",
   "dependencies": {
-    "nan": "~1.3.0"
+    "nan": "~1.5.0"
   },
   "os": [
     "darwin"


### PR DESCRIPTION
Upgrade NaN to 1.5 to support io.js

Rework the `FSEvent` to avoid prototypal inheritance from a constructor that is backed by a `v8::ObjectTemplate` instance. Inherit from `EventEmitter` instead and mix in `Native.FSEvent` methods via a lightway proxy.

Kudos to @bnoordhuis for explaining the reason and showing a solution in https://github.com/bajtos/fsevents/pull/1

Before this change in place, the tests were failing on io.js 1.0.1 with

```
Assertion failed: (handle->InternalFieldCount() > 0), function Wrap, file /Users/bajtos/.node-gyp/1.0.1/src/node_object_wrap.h, line 56.
```

@pipobscure could you please review, land and release this PR as soon as reasonably possible? Your module is used e.g. by Karma test runner, thus most front-end people cannot upgrade to io.js until this fix is landed.